### PR TITLE
Refractor

### DIFF
--- a/example/src/pages/index.html
+++ b/example/src/pages/index.html
@@ -5,8 +5,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Simple Demo</title>
+  <style>#a{color: red}*{padding-left: 3rem}</style>
 </head>
 <body>
   <h1>Welcome to simple. Take a look at <a href="https://github.com/Tnixc/simple">the github</a> to get started</h1>
+  <Hello />
+  <Slot><h1 id="a">hi inside the slot</h1></Slot>
+  <Prop class='el"sde' something="props passing" />
+  <Slot></Slot>
+  <h1>hi from index</h1>
 </body>
 </html>

--- a/src/component_handler.rs
+++ b/src/component_handler.rs
@@ -1,6 +1,6 @@
 use crate::error::{ErrorType, MapPageError, PageHandleError, WithItem};
 use crate::page_processor::page;
-use crate::utils::{get_inside, kv_replace, targets_kv};
+use crate::utils::{get_inside, kv_replace, get_targets_kv};
 use color_print::cprintln;
 use fancy_regex::Regex;
 use std::{collections::HashSet, fs, path::PathBuf};
@@ -109,7 +109,7 @@ pub fn process_component(
                 .trim_end_matches(">")
                 .trim();
             let name = trim.split_whitespace().next().unwrap_or(trim);
-            let targets = targets_kv(name, found.as_str())?;
+            let targets = get_targets_kv(name, found.as_str())?;
 
             if component_type == "self" {
                 let target = found.as_str();

--- a/src/component_handler.rs
+++ b/src/component_handler.rs
@@ -1,0 +1,129 @@
+use crate::utils::{kv_replace, targets_kv, get_inside};
+use crate::page_processor::page;
+use crate::error::{PageHandleError, ErrorType, WithItem, MapPageError};
+use std::{collections::HashSet, fs, path::PathBuf};
+use fancy_regex::Regex;
+
+const COMPONENT_PATTERN_SELF: &str =
+    r#"(?<!<!--)<([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)(\s+[A-Za-z]+=(['\"]).*?\4)*\s*\/>(?!.*?-->)"#;
+
+const COMPONENT_PATTERN_OPEN: &str =
+    r#"(?<!<!--)<([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)(\s+[A-Za-z]+=(['\"]).*?\4)*\s*>(?!.*?-->)"#;
+
+const SLOT_PATTERN: &str = r#"(?<!<!--)<slot([\S\s])*>*?<\/slot>(?!.*?-->)"#;
+
+pub fn get_component_self(
+    src: &PathBuf,
+    component: &str,
+    targets: Vec<(&str, &str)>,
+    mut hist: HashSet<PathBuf>,
+) -> Result<String, PageHandleError> {
+    let path = src
+        .join("components")
+        .join(component.replace(":", "/"))
+        .with_extension("component.html");
+
+    let v = fs::read(&path).map_page_err(WithItem::Component, ErrorType::NotFound, &path)?;
+    let mut st = String::from_utf8(v).map_page_err(WithItem::Component, ErrorType::Utf8, &path)?;
+    st = kv_replace(targets, st);
+    let contents = st.clone().into_bytes();
+    if !hist.insert(path.clone()) {
+        return Err(PageHandleError {
+            error_type: ErrorType::Circular,
+            item: WithItem::Component,
+            path: PathBuf::from(path),
+        });
+    }
+    return page(src, contents, false, hist);
+}
+
+pub fn get_component_slot(
+    src: &PathBuf,
+    component: &str,
+    targets: Vec<(&str, &str)>,
+    slot_content: Option<String>,
+    mut hist: HashSet<PathBuf>,
+) -> Result<String, PageHandleError> {
+    let path = src
+        .join("components")
+        .join(component.replace(":", "/"))
+        .with_extension("component.html");
+    let v = fs::read(&path).map_page_err(WithItem::Component, ErrorType::NotFound, &path)?;
+    let mut st = String::from_utf8(v).expect("Contents of component is not UTF8");
+    if !st.contains("<slot>") || !st.contains("</slot>") {
+        return Err(PageHandleError {
+            error_type: ErrorType::Syntax,
+            item: WithItem::Component,
+            path: PathBuf::from(component),
+        });
+    }
+
+    st = kv_replace(targets, st);
+    if let Some(content) = slot_content {
+        let re = Regex::new(SLOT_PATTERN).expect("Failed to parse regex");
+        st = re.replace(&st, "<slot></slot>").to_string();
+        st = st.replace("</slot>", &(content + "</slot>"));
+    }
+    if !hist.insert(path.clone()) {
+        return Err(PageHandleError {
+            error_type: ErrorType::Circular,
+            item: WithItem::Component,
+            path: PathBuf::from(path),
+        });
+    }
+
+    return page(src, st.into_bytes(), false, hist);
+}
+
+pub fn process_component(
+    src: &PathBuf,
+    string: &mut String,
+    component_type: &str,
+    hist: HashSet<PathBuf>,
+) -> Result<(), PageHandleError> {
+    let pattern = match component_type {
+        "self" => COMPONENT_PATTERN_SELF,
+        "open" => COMPONENT_PATTERN_OPEN,
+        _ => return Err(PageHandleError {
+            error_type: ErrorType::Syntax,
+            item: WithItem::Component,
+            path: PathBuf::from("unknown"),
+        }),
+    };
+
+    let re = Regex::new(pattern).expect("Regex failed to parse. This shouldn't happen.");
+
+    let mut replacements = Vec::new();
+
+    for f in re.find_iter(&string.to_owned()) {
+        if let Ok(found) = f {
+            let trim = found
+                .as_str()
+                .trim()
+                .trim_start_matches("<")
+                .trim_end_matches("/>")
+                .trim_end_matches(">")
+                .trim();
+            let name = trim.split_whitespace().next().unwrap_or(trim);
+            let targets = targets_kv(name, found.as_str())?;
+
+            let replacement = if component_type == "self" {
+                get_component_self(src, name, targets, hist.clone())?
+            } else {
+                let end = format!("</{}>", &name);
+                let slot_content = get_inside(string, found.as_str(), &end);
+                let result = get_component_slot(src, name, targets, slot_content.clone(), hist.clone())?;
+                replacements.push((end.to_string(), String::new()));
+                result
+            };
+
+            replacements.push((found.as_str().to_string(), replacement));
+        }
+    }
+
+    for (old, new) in replacements.into_iter().rev() {
+        *string = string.replacen(&old, &new, 1);
+    }
+
+    Ok(())
+}

--- a/src/dev.html
+++ b/src/dev.html
@@ -1,4 +1,3 @@
-pub const SCRIPT: &str = r#"
 <script>
 /*
  Live.js - One script closer to Designing in the Browser
@@ -234,4 +233,3 @@ pub const SCRIPT: &str = r#"
    console.log("Live.js doesn't support the file protocol. It needs http.");
 })();
 </script>
-"#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
+mod component_handler;
 mod error;
 mod markdown;
 mod new;
 mod page_processor;
 mod template_handler;
-mod component_handler;
 mod utils;
 use color_print::{cformat, cprintln};
 use error::MapPageError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
-mod dev;
 mod error;
 mod markdown;
 mod new;
+mod page_processor;
+mod template_handler;
+mod component_handler;
 mod utils;
 use color_print::{cformat, cprintln};
 use error::MapPageError;
@@ -75,7 +77,7 @@ fn build(args: Vec<String>, dev: bool) -> Result<(), PageHandleError> {
         fs::create_dir(dir.join(s)).map_page_err(File, NotFound, &PathBuf::from(dir.join(s)))?;
     }
 
-    utils::process_pages(&dir, &src, src.clone(), pages, dev)?;
+    page_processor::process_pages(&dir, &src, src.clone(), pages, dev)?;
 
     utils::copy_into(&public, &dist)?;
     let duration = Instant::now().duration_since(start).as_millis();

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -5,6 +5,7 @@ use comrak::Plugins;
 use fancy_regex::Regex;
 
 const MARKDOWN_ELEMENT_PATTERN: &str = r#"(?<!<!--)<markdown>([\s\S]+?)<\/markdown>(?!-->)"#;
+
 pub fn markdown_element(mut string: String) -> String {
     let codefence_syntax_highlighter = SyntectAdapterBuilder::new().theme("base16-mocha.dark");
     let mut plugins = Plugins::default();

--- a/src/page_processor.rs
+++ b/src/page_processor.rs
@@ -1,7 +1,7 @@
 use crate::component_handler::process_component;
-use crate::template_handler::process_template;
-use crate::error::{PageHandleError, ErrorType, WithItem, MapPageError};
+use crate::error::{ErrorType, MapPageError, PageHandleError, WithItem};
 use crate::markdown::markdown_element;
+use crate::template_handler::process_template;
 use std::{collections::HashSet, fs, io::Write, path::PathBuf};
 
 const SCRIPT: &str = include_str!("dev.html");
@@ -12,19 +12,21 @@ pub fn page(
     dev: bool,
     hist: HashSet<PathBuf>,
 ) -> Result<String, PageHandleError> {
-    let mut string = String::from_utf8(contents).map_page_err(WithItem::File, ErrorType::Io, src)?;
+    let mut string =
+        String::from_utf8(contents).map_page_err(WithItem::File, ErrorType::Io, src)?;
 
     if string.contains("</markdown>") {
         string = markdown_element(string);
     }
 
-    process_component(src, &mut string, "self", hist.clone())?;
     process_component(src, &mut string, "open", hist.clone())?;
+    process_component(src, &mut string, "self", hist.clone())?;
     process_template(src, &mut string, hist.clone())?;
 
     if dev {
         string = string.replace("<head>", &format!("<head>{}", SCRIPT));
     }
+
     Ok(string)
 }
 
@@ -56,9 +58,21 @@ pub fn process_pages(
                         .unwrap(),
                 );
 
-                fs::create_dir_all(out_path.parent().unwrap()).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
-                let mut f = std::fs::File::create(&out_path).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
-                f.write_all(result.as_bytes()).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
+                fs::create_dir_all(out_path.parent().unwrap()).map_page_err(
+                    WithItem::File,
+                    ErrorType::Io,
+                    &out_path,
+                )?;
+                let mut f = std::fs::File::create(&out_path).map_page_err(
+                    WithItem::File,
+                    ErrorType::Io,
+                    &out_path,
+                )?;
+                f.write_all(result.as_bytes()).map_page_err(
+                    WithItem::File,
+                    ErrorType::Io,
+                    &out_path,
+                )?;
             }
         }
     }

--- a/src/page_processor.rs
+++ b/src/page_processor.rs
@@ -1,0 +1,66 @@
+use crate::component_handler::process_component;
+use crate::template_handler::process_template;
+use crate::error::{PageHandleError, ErrorType, WithItem, MapPageError};
+use crate::markdown::markdown_element;
+use std::{collections::HashSet, fs, io::Write, path::PathBuf};
+
+const SCRIPT: &str = include_str!("dev.html");
+
+pub fn page(
+    src: &PathBuf,
+    contents: Vec<u8>,
+    dev: bool,
+    hist: HashSet<PathBuf>,
+) -> Result<String, PageHandleError> {
+    let mut string = String::from_utf8(contents).map_page_err(WithItem::File, ErrorType::Io, src)?;
+
+    if string.contains("</markdown>") {
+        string = markdown_element(string);
+    }
+
+    process_component(src, &mut string, "self", hist.clone())?;
+    process_component(src, &mut string, "open", hist.clone())?;
+    process_template(src, &mut string, hist.clone())?;
+
+    if dev {
+        string = string.replace("<head>", &format!("<head>{}", SCRIPT));
+    }
+    Ok(string)
+}
+
+pub fn process_pages(
+    dir: &PathBuf,
+    src: &PathBuf,
+    source: PathBuf,
+    pages: PathBuf,
+    dev: bool,
+) -> Result<(), PageHandleError> {
+    let entries = fs::read_dir(pages).map_page_err(WithItem::File, ErrorType::Io, src)?;
+    let s = if dev { "dev" } else { "dist" };
+    for entry in entries {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            if path.is_dir() {
+                process_pages(&dir, &src, source.join(&path), path, dev)?;
+            } else {
+                let result = page(
+                    src,
+                    fs::read(&path).map_page_err(WithItem::File, ErrorType::Io, &path)?,
+                    dev,
+                    HashSet::new(),
+                )?;
+                let out_path = dir.join(s).join(
+                    path.strip_prefix(src)
+                        .unwrap()
+                        .strip_prefix("pages")
+                        .unwrap(),
+                );
+
+                fs::create_dir_all(out_path.parent().unwrap()).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
+                let mut f = std::fs::File::create(&out_path).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
+                f.write_all(result.as_bytes()).map_page_err(WithItem::File, ErrorType::Io, &out_path)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/template_handler.rs
+++ b/src/template_handler.rs
@@ -1,0 +1,89 @@
+use crate::page_processor::page;
+use crate::error::{PageHandleError, ErrorType, WithItem, MapPageError};
+use std::{collections::HashSet, fs, path::PathBuf, str};
+use serde_json::Value;
+use fancy_regex::Regex;
+
+const TEMPLATE_PATTERN: &str =
+    r#"(?<!<!--)<-Template\{([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)\}\s*\/>(?!.*?-->)"#;
+
+pub fn get_template(
+    src: &PathBuf,
+    name: &str,
+    mut hist: HashSet<PathBuf>,
+) -> Result<String, PageHandleError> {
+    let template_path = src
+        .join("templates")
+        .join(name.replace(":", "/"))
+        .with_extension("template.html");
+
+    let data_path = src
+        .join("data")
+        .join(name.replace(":", "/"))
+        .with_extension("data.json");
+
+    let template_content_utf =
+        fs::read(&template_path).map_page_err(WithItem::Template, ErrorType::NotFound, &template_path)?;
+    let template =
+        String::from_utf8(template_content_utf).map_page_err(WithItem::Template, ErrorType::Utf8, &template_path)?;
+
+    let data_content_utf8 = fs::read(&data_path).map_page_err(WithItem::Data, ErrorType::NotFound, &data_path)?;
+    let data_str = str::from_utf8(&data_content_utf8).unwrap();
+    let v: Value = serde_json::from_str(data_str).expect("JSON decode error");
+    let items = v.as_array().expect("JSON wasn't an array");
+
+    let mut contents = String::new();
+    for object in items {
+        let mut this = template.clone();
+        for (key, value) in object.as_object().expect("Invalid object in JSON") {
+            let key = format!("${{{key}}}");
+            this = this.replace(
+                key.as_str(),
+                value
+                    .as_str()
+                    .expect("JSON object value couldn't be decoded to string"),
+            );
+        }
+        contents.push_str(&this);
+    }
+    if !hist.insert(template_path.clone()) {
+        return Err(PageHandleError {
+            error_type: ErrorType::Circular,
+            item: WithItem::Template,
+            path: template_path,
+        });
+    }
+    return page(src, contents.into_bytes(), false, hist);
+}
+
+pub fn process_template(
+    src: &PathBuf,
+    string: &mut String,
+    hist: HashSet<PathBuf>,
+) -> Result<(), PageHandleError> {
+    let re_template =
+        Regex::new(TEMPLATE_PATTERN).expect("Regex failed to parse. This shouldn't happen.");
+    
+    let mut replacements = Vec::new();
+
+    for f in re_template.find_iter(string) {
+        if let Ok(found) = f {
+            let template_name = found
+                .as_str()
+                .trim()
+                .trim_start_matches("<-Template{")
+                .trim_end_matches("/>")
+                .trim()
+                .trim_end_matches("}");
+            
+            let replacement = get_template(src, template_name, hist.clone())?;
+            replacements.push((found.as_str().to_string(), replacement));
+        }
+    }
+
+    for (old, new) in replacements.into_iter().rev() {
+        *string = string.replacen(&old, &new, 1);
+    }
+
+    Ok(())
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::error::ErrorType::Io;
-use crate::error::{MapPageError, ErrorType, PageHandleError, WithItem};
+use crate::error::{ErrorType, MapPageError, PageHandleError, WithItem};
 use fancy_regex::Regex;
 use std::fs;
 use std::path::PathBuf;
@@ -10,6 +10,7 @@ pub fn targets_kv<'a>(
     found: &'a str,
 ) -> Result<Vec<(&'a str, &'a str)>, PageHandleError> {
     let mut targets: Vec<(&str, &str)> = Vec::new();
+    // Regex for key-value pairs in components
     let re = Regex::new(r#"(\w+)=(['"])(?:(?!\2).)*\2"#).unwrap();
     let str = found
         .trim_start_matches(&("<".to_owned() + name))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 use WithItem::File;
 
-pub fn targets_kv<'a>(
+pub fn get_targets_kv<'a>(
     name: &str,
     found: &'a str,
 ) -> Result<Vec<(&'a str, &'a str)>, PageHandleError> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,270 +1,62 @@
-use crate::dev::SCRIPT;
-use std::collections::HashSet;
-use crate::error::MapPageError;
-use crate::error::{ErrorType, PageHandleError, WithItem};
-use crate::markdown::markdown_element;
+use crate::error::ErrorType::Io;
+use crate::error::{MapPageError, ErrorType, PageHandleError, WithItem};
 use fancy_regex::Regex;
-use serde_json::Value;
-use std::{fs, io::Write, path::PathBuf, str};
-use ErrorType::{Io, NotFound, Syntax, Utf8, Circular};
-use WithItem::{Component, Data, File, Template};
+use std::fs;
+use std::path::PathBuf;
+use WithItem::File;
 
-const COMPONENT_PATTERN_OPEN: &str =
-    r#"(?<!<!--)<([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)(\s+[A-Za-z]+=(['\"]).*?\4)*\s*>(?!.*?-->)"#;
-
-const COMPONENT_PATTERN_SELF: &str =
-    r#"(?<!<!--)<([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)(\s+[A-Za-z]+=(['\"]).*?\4)*\s*\/>(?!.*?-->)"#;
-
-const TEMPLATE_PATTERN: &str =
-    r#"(?<!<!--)<-Template\{([A-Z][A-Za-z_]*(:[A-Z][A-Za-z_]*)*)\}\s*\/>(?!.*?-->)"#;
-
-const SLOT_PATTERN: &str = r#"(?<!<!--)<slot([\S\s])*>*?<\/slot>(?!.*?-->)"#;
-
-const CLASS_PATTERN: &str = r#"(\w+)=(['"])(?:(?!\2).)*\2"#;
-// Thank you Claude, couldn't have done this Regex-ing without you.
-
-pub fn sub_component_self(
-    src: &PathBuf,
-    component: &str,
-    targets: Vec<(&str, &str)>,
-    mut hist: HashSet<PathBuf>,
-) -> Result<String, PageHandleError> {
-    let path = src
-        .join("components")
-        .join(component.replace(":", "/"))
-        .with_extension("component.html");
-
-    let v = fs::read(&path).map_page_err(Component, NotFound, &path)?;
-    let mut st = String::from_utf8(v).map_page_err(Component, Utf8, &path)?;
-    st = kv_replace(targets, st);
-    let contents = st.clone().into_bytes();
-    if !hist.insert(path.clone()) {
-        return Err(PageHandleError { error_type: Circular, item: Component, path: PathBuf::from(path) })
-    }
-    return page(src, contents, false, hist);
-}
-
-pub fn sub_component_slot(
-    src: &PathBuf,
-    component: &str,
-    targets: Vec<(&str, &str)>,
-    slot_content: Option<String>,
-    mut hist: HashSet<PathBuf>,
-) -> Result<String, PageHandleError> {
-    let path = src
-        .join("components")
-        .join(component.replace(":", "/"))
-        .with_extension("component.html");
-    let v = fs::read(&path).map_page_err(Component, NotFound, &path)?;
-    let mut st = String::from_utf8(v).expect("Contents of component is not UTF8");
-
-    if !st.contains("<slot>") || !st.contains("</slot>") {
-        return Err(PageHandleError {
-            error_type: Syntax,
-            item: Component,
-            path: PathBuf::from(component),
-        });
-    }
-
-    st = kv_replace(targets, st);
-    if slot_content.is_some() {
-        let re = Regex::new(SLOT_PATTERN).expect("Failed to parse regex");
-        st = re.replace(&st, "<slot></slot>").to_string();
-        st = st.replace("</slot>", &(slot_content.unwrap() + "</slot>"));
-    }
-    if !hist.insert(path.clone()) {
-        return Err(PageHandleError { error_type: Circular, item: Component, path: PathBuf::from(path) })
-    }
-
-    return page(src, st.into_bytes(), false, hist);
-}
-
-pub fn sub_template(
-    src: &PathBuf,
+pub fn targets_kv<'a>(
     name: &str,
-    mut hist: HashSet<PathBuf>,
-) -> Result<String, PageHandleError> {
-    let template_path = src
-        .join("templates")
-        .join(name.replace(":", "/"))
-        .with_extension("template.html");
+    found: &'a str,
+) -> Result<Vec<(&'a str, &'a str)>, PageHandleError> {
+    let mut targets: Vec<(&str, &str)> = Vec::new();
+    let re = Regex::new(r#"(\w+)=(['"])(?:(?!\2).)*\2"#).unwrap();
+    let str = found
+        .trim_start_matches(&("<".to_owned() + name))
+        .trim_end_matches(">")
+        .trim_end_matches("/>");
 
-    let data_path = src
-        .join("data")
-        .join(name.replace(":", "/"))
-        .with_extension("data.json");
-
-    let template_content_utf =
-        fs::read(&template_path).map_page_err(Template, NotFound, &template_path)?;
-    let template =
-        String::from_utf8(template_content_utf).map_page_err(Template, Utf8, &template_path)?;
-
-    let data_content_utf8 = fs::read(&data_path).map_page_err(Data, NotFound, &data_path)?;
-    let data_str = str::from_utf8(&data_content_utf8).unwrap();
-    let v: Value = serde_json::from_str(data_str).expect("JSON decode error");
-    let items = v.as_array().expect("JSON wasn't an array");
-
-    let mut contents = String::new();
-    for object in items {
-        let mut this = template.clone();
-        for (key, value) in object.as_object().expect("Invalid object in JSON") {
-            let key = format!("${{{key}}}");
-            this = this.replace(
-                key.as_str(),
-                value
-                    .as_str()
-                    .expect("JSON object value couldn't be decoded to string"),
-            );
-        }
-        contents.push_str(&this);
-    }
-    if !hist.insert(template_path.clone()) {
-        return Err(PageHandleError { error_type: Circular, item: Template, path: template_path })
-    }
-    return page(src, contents.into_bytes(), false, hist);
-}
-
-fn page(
-    src: &PathBuf,
-    contents: Vec<u8>,
-    dev: bool,
-    hist: HashSet<PathBuf>,
-) -> Result<String, PageHandleError> {
-
-    let mut string = String::from_utf8(contents).map_page_err(File, Io, src)?;
-
-    if string.contains("</markdown>") {
-        string = markdown_element(string);
-    }
-    let re_component_self =
-        Regex::new(COMPONENT_PATTERN_SELF).expect("Regex failed to parse. This shouldn't happen.");
-
-    for f in re_component_self.find_iter(&string.to_owned()) {
-        if f.is_ok() {
-            let found = f.unwrap();
-            let trim = found
-                .as_str()
-                .trim()
-                .trim_start_matches("<")
-                .trim_end_matches("/>")
-                .trim();
-            let name = trim.split_whitespace().next().unwrap_or(trim);
-            let targets = targets_kv(name, found.as_str())?;
-            string = string.replacen(
-                found.as_str(),
-                &sub_component_self(src, name, targets, hist.clone())?,
-                1,
-            );
-        }
-    }
-
-    let re_component_open =
-        Regex::new(COMPONENT_PATTERN_OPEN).expect("Regex failed to parse. This shouldn't happen.");
-
-    for f in re_component_open.find_iter(&string.to_owned()) {
-        if f.is_ok() {
-            let found = f.unwrap();
-            let trim = found
-                .as_str()
-                .trim()
-                .trim_start_matches("<")
-                .trim_end_matches(">")
-                .trim();
-            let name = trim.split_whitespace().next().unwrap_or(trim);
-            let end = format!("</{}>", &name);
-
-            let targets = targets_kv(name, found.as_str())?;
-            let slot_content = get_inside(&string, found.as_str(), &end);
-            if slot_content.is_some() {
-                let from = found.as_str().to_owned() + &(slot_content.as_ref().unwrap().clone());
-                string = string.replacen(
-                    &from,
-                    &sub_component_slot(src, name, targets, slot_content, hist.clone())?,
-                    1,
-                );
+    for item in re.find_iter(str) {
+        if let Ok(item) = item {
+            if let Some((k, mut v)) = item.as_str().split_once('=') {
+                v = v.trim_matches(|c| c == '\'' || c == '"');
+                targets.push((k, v));
             } else {
-                string = string.replacen(
-                    &found.as_str().to_owned(),
-                    &sub_component_slot(src, name, targets, slot_content, hist.clone())?,
-                    1,
-                )
+                return Err(PageHandleError {
+                    error_type: ErrorType::Syntax,
+                    item: WithItem::Component,
+                    path: PathBuf::from(name),
+                });
             }
-
-            string = string.replacen(&end, "", 1);
+        } else {
+            return Err(PageHandleError {
+                error_type: ErrorType::Syntax,
+                item: WithItem::Component,
+                path: PathBuf::from(name),
+            });
         }
     }
-
-    let re_template =
-        Regex::new(TEMPLATE_PATTERN).expect("Regex failed to parse. This shouldn't happen.");
-    for f in re_template.find_iter(&string.clone()) {
-        if f.is_ok() {
-            let found = f.unwrap();
-            string = string.replacen(
-                found.as_str(),
-                &sub_template(
-                    src,
-                    found
-                        .as_str()
-                        .trim()
-                        .trim_start_matches("<-Template{")
-                        .trim_end_matches("/>")
-                        .trim()
-                        .trim_end_matches("}"),
-                    hist.clone()
-                )?,
-                1,
-            );
-        }
-    }
-
-    if dev {
-        string = string.replace("<head>", ("<head>".to_owned() + SCRIPT).as_str());
-    }
-    return Ok(string);
+    Ok(targets)
 }
 
-pub fn process_pages(
-    dir: &PathBuf,
-    src: &PathBuf,
-    source: PathBuf,
-    pages: PathBuf,
-    dev: bool,
-) -> Result<(), PageHandleError> {
-    // dir is the root.
-    let entries = fs::read_dir(pages).map_page_err(File, Io, src)?;
-    let s;
-    if dev {
-        s = "dev"
-    } else {
-        s = "dist"
+pub fn kv_replace(kv: Vec<(&str, &str)>, mut from: String) -> String {
+    for (k, v) in kv {
+        let key = format!("${{{k}}}");
+        from = from.replace(&key, v);
     }
-    for entry in entries {
-        if entry.as_ref().unwrap().path().is_dir() {
-            let this = entry.unwrap().path();
-            process_pages(&dir, &src, source.join(&this), this, dev)?;
-        } else {
-            let result = page(
-                src,
-                fs::read(entry.as_ref().unwrap().path()).unwrap(),
-                dev,
-                HashSet::new(),
-            );
-            let path = dir.join(s).join(
-                entry
-                    .unwrap()
-                    .path()
-                    .strip_prefix(src)
-                    .unwrap()
-                    .strip_prefix("pages")
-                    .unwrap(),
-            );
+    from
+}
 
-            fs::create_dir_all(path.parent().unwrap()).map_page_err(File, Io, &path)?;
-            let mut f = std::fs::File::create(&path).map_page_err(File, Io, &path)?;
-            f.write(result?.as_bytes()).map_page_err(File, Io, &path)?;
-        }
+pub fn get_inside(input: &str, from: &str, to: &str) -> Option<String> {
+    let start_index = input.find(from)?;
+    let start_pos = start_index + from.len();
+    let end_index = input[start_pos..].find(to).map(|i| i + start_pos)?;
+
+    if start_pos >= end_index {
+        None
+    } else {
+        Some(input[start_pos..end_index].to_string())
     }
-    Ok(())
 }
 
 pub fn copy_into(public: &PathBuf, dist: &PathBuf) -> Result<(), PageHandleError> {
@@ -288,63 +80,4 @@ pub fn copy_into(public: &PathBuf, dist: &PathBuf) -> Result<(), PageHandleError
         }
     }
     Ok(())
-}
-
-fn targets_kv<'a>(name: &str, found: &'a str) -> Result<Vec<(&'a str, &'a str)>, PageHandleError> {
-    let mut targets: Vec<(&str, &str)> = Vec::new();
-    let re = Regex::new(CLASS_PATTERN).unwrap();
-    let str = found
-        .trim_start_matches(&("<".to_owned() + name))
-        .trim_end_matches(">");
-
-    for item in re.find_iter(str) {
-        if item.is_ok() {
-            match item.unwrap().as_str().split_once("=") {
-                Some((k, mut v)) => {
-                    if v.starts_with("'") {
-                        v = v.trim_start_matches("'").trim_end_matches("'");
-                    } else if v.starts_with("\"") {
-                        v = v.trim_start_matches("\"").trim_end_matches("\"");
-                    }
-                    targets.push((k, v))
-                }
-                None => {
-                    eprintln!("Equals not found when parsing props.");
-                    return Err(PageHandleError {
-                        error_type: Syntax,
-                        item: Component,
-                        path: PathBuf::from(name),
-                    });
-                }
-            }
-        } else {
-            eprintln!("Equals not found when parsing props.");
-            return Err(PageHandleError {
-                error_type: Syntax,
-                item: Component,
-                path: PathBuf::from(name),
-            });
-        }
-    }
-    return Ok(targets);
-}
-
-fn kv_replace(kv: Vec<(&str, &str)>, mut from: String) -> String {
-    for (k, v) in kv {
-        let key = format!("${{{k}}}");
-        from = from.replace(&key, v);
-    }
-    return from;
-}
-
-fn get_inside(input: &str, from: &str, to: &str) -> Option<String> {
-    let start_index = input.find(from)?;
-    let start_pos = start_index + from.len();
-    let end_index = input[start_pos..].find(to).map(|i| i + start_pos)?;
-
-    if start_pos >= end_index {
-        None
-    } else {
-        Some(input[start_pos..end_index].to_string())
-    }
 }


### PR DESCRIPTION
This splits aparts the template and component handling functions, puts them in separate files, and cleans up the component function. It should also fix a big where `<slot>` is left in the result sometimes.